### PR TITLE
🐛 fix(pools-client): align wire attributes with server (tokenX/tokenY…

### DIFF
--- a/apps/docs/beans/tributary-u4a8--pools-client-align-wire-attributes-with-server-tok.md
+++ b/apps/docs/beans/tributary-u4a8--pools-client-align-wire-attributes-with-server-tok.md
@@ -1,0 +1,48 @@
+---
+# tributary-u4a8
+title: 'pools-client: align wire attributes with server (tokenX/tokenY/logoUri, not snake_case)'
+status: completed
+type: bug
+priority: high
+created_at: 2026-08-02T20:28:47Z
+updated_at: 2026-08-02T20:37:01Z
+---
+
+The server (apps/api/src/routes/pools.ts) delivers pool legs as tokenX/tokenY/logoUri (camelCase). The @tributary-so/pools-client package types declare token_x/token_y/logo_uri (snake_case) — a wire contract mismatch. Any consumer of the published client would see undefined fields at runtime.
+
+## Scope
+- [ ] types.ts: PoolToken.logo_uri -> logoUri, PoolSearchResult.token_x/token_y -> tokenX/tokenY
+- [ ] picker.tsx: all pool.token_x/token_y/logo_uri reads -> camelCase
+- [ ] client.test.ts: fixtures -> camelCase
+- [ ] picker.test.ts: fixtures -> camelCase
+- [ ] react.test.ts: fixtures -> camelCase
+- [ ] README.md: Types section -> camelCase
+- [ ] pnpm test (all three self-checks pass)
+- [ ] pnpm run build (tsc clean)
+- [ ] pnpm run lint
+
+## Out of scope
+- DB SQL column names stay logo_uri (schema-pools.ts text("logo_uri") is the column mapping).
+- POOL-API.md line 88 describes the DB column, not the wire.
+- Historical bean bodies under apps/docs/beans are immutable.
+
+## Summary of Changes
+
+The server (`apps/api/src/routes/pools.ts`) delivers pool legs as `tokenX`/`tokenY`/`logoUri` (camelCase) but `@tributary-so/pools-client` declared `token_x`/`token_y`/`logo_uri` (snake_case) — a wire contract mismatch that would surface every leg field as `undefined` for any consumer.
+
+### Files changed
+- `src/types.ts` — `PoolToken.logo_uri`→`logoUri`; `PoolSearchResult.token_x/token_y`→`tokenX/tokenY`.
+- `src/picker.tsx` — all `pool.token_x`/`pool.token_y`/`token.logo_uri` reads → camelCase (`legMeta`, `resolvePoolDirection`, `impliedPoolDirection`, `PoolRow`).
+- `src/client.test.ts` — both fixtures (happy path + thin pool) + assertions → camelCase.
+- `src/picker.test.ts` — `pool()` factory + all override fixtures (`stableX`, `noStable`, `unknown`) → camelCase.
+- `src/react.test.ts` — fixture + assertion → camelCase.
+- `README.md` — Types section → camelCase.
+
+### Out of scope (intentionally untouched)
+- `apps/api/src/db/schema-pools.ts` `text("logo_uri")` and `db/pools.ts` `excluded.logo_uri` — SQL column identifiers (drizzle JS name → SQL column mapping), not wire attributes.
+- Comment/message strings in `picker.test.ts` referencing `token_x`/`token_y` as the pool-leg *concept* ("the X token"), not field accesses.
+
+### Verification
+- `pnpm run build` (tsc): clean
+- `pnpm test`: all 3 self-checks pass (client, react hook, picker helpers)
+- `pnpm run lint`: clean

--- a/packages/pools-client/README.md
+++ b/packages/pools-client/README.md
@@ -193,15 +193,15 @@ interface PoolToken {
   mint: string; // Solana base58
   symbol: string | null;
   decimals: number | null;
-  logo_uri: string | null;
+  logoUri: string | null;
   tier: TokenTier;
 }
 
 interface PoolSearchResult {
   address: string; // Pool account (base58)
   venue: PoolVenue;
-  token_x: PoolToken;
-  token_y: PoolToken;
+  tokenX: PoolToken;
+  tokenY: PoolToken;
   tvl: number | null; // USD at last sync
   feeRate: number | null; // FRACTION (0.0025 = 0.25%) — venue-normalized server-side
   stars: number; // 0|1|2 — one per known leg token

--- a/packages/pools-client/src/client.test.ts
+++ b/packages/pools-client/src/client.test.ts
@@ -59,18 +59,18 @@ async function main(): Promise<void> {
       {
         address: "7QBQ6qXqLpMzHk8oM3pZ5nR1tY6uVxW2vK4jF3dCeGaH",
         venue: "raydium",
-        token_x: {
+        tokenX: {
           mint: "So11111111111111111111111111111111111111112",
           symbol: "SOL",
           decimals: 9,
-          logo_uri: null,
+          logoUri: null,
           tier: "tier1",
         },
-        token_y: {
+        tokenY: {
           mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // gitleaks:allow — public USDC mint
           symbol: "USDC",
           decimals: 6,
-          logo_uri: "https://x/usdc.png",
+          logoUri: "https://x/usdc.png",
           tier: "tier1",
         },
         tvl: 1_200_000.5,
@@ -88,10 +88,10 @@ async function main(): Promise<void> {
   assert(r.results.length === 1, "search should return 1 result");
   assert(r.venue === "raydium", "envelope venue mismatch");
   const pool = r.results[0];
-  assert(pool.token_x.symbol === "SOL", "token_x symbol mismatch");
+  assert(pool.tokenX.symbol === "SOL", "tokenX symbol mismatch");
   assert(
-    pool.token_y.mint === "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // gitleaks:allow — public USDC mint
-    "token_y mint mismatch"
+    pool.tokenY.mint === "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // gitleaks:allow — public USDC mint
+    "tokenY mint mismatch"
   );
   assert(pool.stars === 2, "stars mismatch");
   assert(pool.tier1 === true, "tier1 mismatch");
@@ -168,18 +168,18 @@ async function main(): Promise<void> {
       {
         address: "Po1PooooWoRtHlEss3333333333333333333333333",
         venue: "raydium",
-        token_x: {
+        tokenX: {
           mint: "UnkMintAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           symbol: null,
           decimals: null,
-          logo_uri: null,
+          logoUri: null,
           tier: null,
         },
-        token_y: {
+        tokenY: {
           mint: "UnkMintBbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
           symbol: null,
           decimals: null,
-          logo_uri: null,
+          logoUri: null,
           tier: null,
         },
         tvl: null,
@@ -192,7 +192,7 @@ async function main(): Promise<void> {
   );
   const thin = await client.searchPools("unk", { venue: "raydium" });
   assert(thin.results.length === 1, "thin pool should parse");
-  assert(thin.results[0].token_x.symbol === null, "null symbol should survive");
+  assert(thin.results[0].tokenX.symbol === null, "null symbol should survive");
   assert(thin.results[0].stars === 0, "0 stars should survive");
   assert(thin.results[0].tier1 === false, "tier1 false should survive");
 

--- a/packages/pools-client/src/picker.test.ts
+++ b/packages/pools-client/src/picker.test.ts
@@ -35,18 +35,18 @@ function pool(overrides: Partial<PoolSearchResult> = {}): PoolSearchResult {
   return {
     address: "PoolAddr111111111111111111111111111111111111",
     venue: "raydium",
-    token_x: {
+    tokenX: {
       mint: SOL,
       symbol: "SOL",
       decimals: 9,
-      logo_uri: null,
+      logoUri: null,
       tier: "tier1",
     },
-    token_y: {
+    tokenY: {
       mint: USDC,
       symbol: "USDC",
       decimals: 6,
-      logo_uri: "https://x.test/usdc.png",
+      logoUri: "https://x.test/usdc.png",
       tier: "tier1",
     },
     tvl: 1_200_000,
@@ -65,32 +65,32 @@ function main(): void {
   const xDir = resolvePoolDirection(p, "tokenX");
   assert(
     xDir.tgtMint === SOL,
-    "tokenX direction: target should be token_x (SOL)",
+    "tokenX direction: target should be token_x (SOL)"
   );
   assert(
     xDir.srcMint === USDC,
-    "tokenX direction: source should be token_y (USDC)",
+    "tokenX direction: source should be token_y (USDC)"
   );
   assert(xDir.srcMeta.symbol === "USDC", "srcMeta symbol");
-  assert(xDir.tgtMeta.logoUri === null, "tgtMeta logo_uri passthrough");
+  assert(xDir.tgtMeta.logoUri === null, "tgtMeta logoUri passthrough");
 
   const yDir = resolvePoolDirection(p, "tokenY");
   assert(
     yDir.tgtMint === USDC,
-    "tokenY direction: target should be token_y (USDC)",
+    "tokenY direction: target should be token_y (USDC)"
   );
   assert(
     yDir.srcMint === SOL,
-    "tokenY direction: source should be token_x (SOL)",
+    "tokenY direction: source should be token_x (SOL)"
   );
 
   // --- legMeta fallbacks: unknown symbol/decimals never blank the row ---
   const unknown = pool({
-    token_x: {
+    tokenX: {
       mint: SCAM,
       symbol: null,
       decimals: null,
-      logo_uri: null,
+      logoUri: null,
       tier: null,
     },
   });
@@ -98,7 +98,7 @@ function main(): void {
   assert(unknownDir.srcMeta.symbol === "USDC", "known leg still resolves");
   assert(
     unknownDir.tgtMeta.symbol === SCAM.slice(0, 4),
-    "null symbol falls back to mint prefix",
+    "null symbol falls back to mint prefix"
   );
   assert(unknownDir.tgtMeta.decimals === 6, "null decimals default to 6");
 
@@ -106,49 +106,49 @@ function main(): void {
   // SOL/USDC → USDC is the stable (token_y) → accumulate tokenY.
   assert(
     impliedPoolDirection(p) === "tokenY",
-    "implied: accumulate the stable leg (USDC = tokenY)",
+    "implied: accumulate the stable leg (USDC = tokenY)"
   );
-  // Flip so stable is token_x → implied tokenX.
+  // Flip so stable is tokenX → implied tokenX.
   const stableX = pool({
-    token_x: {
+    tokenX: {
       mint: USDC,
       symbol: "USDC",
       decimals: 6,
-      logo_uri: null,
+      logoUri: null,
       tier: "tier1",
     },
-    token_y: {
+    tokenY: {
       mint: SOL,
       symbol: "SOL",
       decimals: 9,
-      logo_uri: null,
+      logoUri: null,
       tier: "tier1",
     },
   });
   assert(
     impliedPoolDirection(stableX) === "tokenX",
-    "implied: stable on token_x → tokenX",
+    "implied: stable on tokenX → tokenX"
   );
   // Neither stable → lexicographic default tokenY.
   const noStable = pool({
-    token_x: {
+    tokenX: {
       mint: SOL,
       symbol: "SOL",
       decimals: 9,
-      logo_uri: null,
+      logoUri: null,
       tier: null,
     },
-    token_y: {
+    tokenY: {
       mint: SCAM,
       symbol: "SCAM",
       decimals: 9,
-      logo_uri: null,
+      logoUri: null,
       tier: null,
     },
   });
   assert(
     impliedPoolDirection(noStable) === "tokenY",
-    "no stable → tokenY default",
+    "no stable → tokenY default"
   );
 
   // --- STABLE_MINTS sanity (display hint set) ---
@@ -167,7 +167,7 @@ function main(): void {
   assert(tgtMint === SOL, "onSelect arg2 = tgtMint (tokenX → token_x)");
   assert(
     extras === p.extras,
-    "onSelect arg3 = venue extras (ammConfig rides here, no client branch)",
+    "onSelect arg3 = venue extras (ammConfig rides here, no client branch)"
   );
   assert(srcMeta.decimals === 6, "onSelect arg4 srcMeta.decimals");
   assert(tgtMeta.tier === "tier1", "onSelect arg5 tgtMeta.tier passthrough");

--- a/packages/pools-client/src/picker.tsx
+++ b/packages/pools-client/src/picker.tsx
@@ -44,7 +44,7 @@ export type PoolSelectHandler = (
   tgtMint: string,
   extras: Record<string, unknown> | null,
   srcMeta: PoolLegMeta,
-  tgtMeta: PoolLegMeta,
+  tgtMeta: PoolLegMeta
 ) => void;
 
 // Curated stablecoin mints for the implied (display) direction —
@@ -56,27 +56,27 @@ export const STABLE_MINTS = new Set([
   "HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr", // EURC
 ]);
 
-function legMeta(token: PoolSearchResult["token_x"]): PoolLegMeta {
+function legMeta(token: PoolSearchResult["tokenX"]): PoolLegMeta {
   return {
     mint: token.mint,
     // Unknown symbol → first 4 mint chars so the row never goes blank.
     symbol: token.symbol ?? token.mint.slice(0, 4),
     // ponytail: decimals default 6 (SPL-ish) when the index lacks it.
     decimals: token.decimals ?? 6,
-    logoUri: token.logo_uri,
+    logoUri: token.logoUri,
     tier: token.tier,
   };
 }
 
 /**
  * Resolve source/target legs from a pool + direction.
- * "Accumulate tokenX" (dir="tokenX") → targetMint = token_x, sourceMint =
- * token_y (you pay token_y to accumulate token_x). Mirrors Mill's prior
+ * "Accumulate tokenX" (dir="tokenX") → targetMint = tokenX, sourceMint =
+ * tokenY (you pay tokenY to accumulate tokenX). Mirrors Mill's prior
  * resolveDirection semantics so the migration is a drop-in.
  */
 export function resolvePoolDirection(
   pool: PoolSearchResult,
-  direction: Direction,
+  direction: Direction
 ): {
   srcMint: string;
   tgtMint: string;
@@ -84,8 +84,8 @@ export function resolvePoolDirection(
   tgtMeta: PoolLegMeta;
 } {
   const targetIsX = direction === "tokenX";
-  const src = targetIsX ? pool.token_y : pool.token_x;
-  const tgt = targetIsX ? pool.token_x : pool.token_y;
+  const src = targetIsX ? pool.tokenY : pool.tokenX;
+  const tgt = targetIsX ? pool.tokenX : pool.tokenY;
   return {
     srcMint: src.mint,
     tgtMint: tgt.mint,
@@ -101,10 +101,10 @@ export function resolvePoolDirection(
  */
 export function impliedPoolDirection(
   pool: PoolSearchResult,
-  stableMints: Set<string> = STABLE_MINTS,
+  stableMints: Set<string> = STABLE_MINTS
 ): Direction {
-  const xStable = stableMints.has(pool.token_x.mint);
-  const yStable = stableMints.has(pool.token_y.mint);
+  const xStable = stableMints.has(pool.tokenX.mint);
+  const yStable = stableMints.has(pool.tokenY.mint);
   return xStable && !yStable ? "tokenX" : "tokenY";
 }
 
@@ -112,7 +112,7 @@ export function impliedPoolDirection(
 export function selectPool(
   pool: PoolSearchResult,
   direction: Direction,
-  onSelect: PoolSelectHandler,
+  onSelect: PoolSelectHandler
 ): void {
   const r = resolvePoolDirection(pool, direction);
   onSelect(
@@ -121,7 +121,7 @@ export function selectPool(
     r.tgtMint,
     pool.extras,
     r.srcMeta,
-    r.tgtMeta,
+    r.tgtMeta
   );
 }
 
@@ -171,15 +171,15 @@ export function PoolRow({ pool, selected, className }: PoolRowProps) {
       className={`flex items-center gap-2 w-full min-w-0 ${className ?? ""}`}
     >
       <PairLogos
-        xUri={pool.token_x.logo_uri}
-        yUri={pool.token_y.logo_uri}
-        xSym={pool.token_x.symbol}
-        ySym={pool.token_y.symbol}
+        xUri={pool.tokenX.logoUri}
+        yUri={pool.tokenY.logoUri}
+        xSym={pool.tokenX.symbol}
+        ySym={pool.tokenY.symbol}
       />
       <span className="text-sm truncate flex-1 min-w-0">
-        {pool.token_x.symbol ?? pool.token_x.mint.slice(0, 4)}
+        {pool.tokenX.symbol ?? pool.tokenX.mint.slice(0, 4)}
         {" / "}
-        {pool.token_y.symbol ?? pool.token_y.mint.slice(0, 4)}
+        {pool.tokenY.symbol ?? pool.tokenY.mint.slice(0, 4)}
       </span>
       <TrustBadge stars={pool.stars} tier1={pool.tier1} />
       <span className="text-xs text-muted-foreground shrink-0 font-mono tabular-nums">

--- a/packages/pools-client/src/react.test.ts
+++ b/packages/pools-client/src/react.test.ts
@@ -107,18 +107,18 @@ async function main(): Promise<void> {
       {
         address: "PoolSOL11111111111111111111111111111111111",
         venue: "raydium",
-        token_x: {
+        tokenX: {
           mint: "So11111111111111111111111111111111111111112",
           symbol: "SOL",
           decimals: 9,
-          logo_uri: null,
+          logoUri: null,
           tier: "tier1",
         },
-        token_y: {
+        tokenY: {
           mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // gitleaks:allow — public USDC mint
           symbol: "USDC",
           decimals: 6,
-          logo_uri: null,
+          logoUri: null,
           tier: "tier1",
         },
         tvl: 9000,
@@ -183,7 +183,7 @@ async function main(): Promise<void> {
       "hook should surface parsed results"
     );
     assert(
-      lastResult?.data?.results[0].token_x.symbol === "SOL",
+      lastResult?.data?.results[0].tokenX.symbol === "SOL",
       "hook result symbol mismatch"
     );
     act(() => root.unmount());

--- a/packages/pools-client/src/types.ts
+++ b/packages/pools-client/src/types.ts
@@ -19,7 +19,7 @@ export interface PoolToken {
   mint: string;
   symbol: string | null;
   decimals: number | null;
-  logo_uri: string | null;
+  logoUri: string | null;
   tier: TokenTier;
 }
 
@@ -28,8 +28,8 @@ export interface PoolSearchResult {
   /** Pool account address (base58). */
   address: string;
   venue: PoolVenue;
-  token_x: PoolToken;
-  token_y: PoolToken;
+  tokenX: PoolToken;
+  tokenY: PoolToken;
   /** TVL in USD at last sync (NUMERIC on the server). */
   tvl: number | null;
   /** Pool fee rate (basis points or fraction — venue-dependent). */


### PR DESCRIPTION
…/logoUri)

The /v1/pools/search server delivers pool legs as camelCase (tokenX, tokenY, logoUri) but the client package typed them as snake_case (token_x, token_y, logo_uri) — a wire contract mismatch that surfaced every leg field as undefined for consumers.

- types.ts: rename PoolToken.logo_uri and PoolSearchResult.token_x/token_y
- picker.tsx: update all leg field reads (legMeta, resolve, implied, PoolRow)
- client/picker/react test fixtures + assertions: camelCase
- README Types section: camelCase

SQL column identifiers in apps/api/src/db/ are unchanged (drizzle JS-to-column mapping, not wire attributes).

Refs: tributary-u4a8