### PR TITLE
🐛 fix(api): resolve pool token symbols from venue before tokens.xyz

### DIFF
--- a/apps/api/src/__tests__/pools.route.test.ts
+++ b/apps/api/src/__tests__/pools.route.test.ts
@@ -26,6 +26,7 @@ jest.mock("../middleware/rateLimit", () => ({
 import poolsRouter from "../routes/pools";
 import { errorHandler } from "../middleware/errorHandler";
 import * as poolsSearch from "../services/pools-search";
+import type { PoolSearchHit } from "../db/pools";
 
 const searchPoolsCached = poolsSearch.searchPoolsCached as jest.MockedFunction<
   typeof poolsSearch.searchPoolsCached
@@ -128,6 +129,51 @@ describe("/v1/pools routes", () => {
         venue: "raydium",
         limit: 10,
       });
+    });
+
+    it("prefers the venue symbol over a stale/uncurated tokens.xyz symbol", async () => {
+      // Regression (MOON/SPCX): tokens.xyz returns tier3 (uncurated) and the
+      // indexed `tokens` row still holds a synthetic slice ("8zTZ...") from
+      // the old writer. The pool row already carries "MOON" — the venue
+      // symbol must win; a registry gap can never shadow a symbol the pool
+      // already gave us.
+      const hit: PoolSearchHit = {
+        pool: {
+          address: "PoolMOON",
+          venue: "raydium",
+          mintA: "8zTZRwvifDrCe237kxKtKWgnQvhfVA7ncMQ7P7qApew",
+          mintB: USDC,
+          symbolA: "MOON",
+          symbolB: "USDC",
+          tvl: "9000",
+          feeRate: "0.03",
+          stars: 0,
+          tier1: false,
+          extras: {},
+          refreshedAt: new Date("2026-08-02T00:00:00Z"),
+        },
+        tokenA: {
+          mint: "8zTZRwvifDrCe237kxKtKWgnQvhfVA7ncMQ7P7qApew",
+          known: false,
+          tier: "tier3",
+          symbol: "8zTZ...",
+          name: null,
+          decimals: 6,
+          logoUri: null,
+          refreshedAt: new Date("2026-08-02T00:00:00Z"),
+        },
+        tokenB: null,
+      };
+      searchPoolsCached.mockResolvedValueOnce([hit]);
+
+      const res = await request(app).get("/v1/pools/search?q=MOON&venue=raydium");
+
+      expect(res.status).toBe(200);
+      const tokenX = res.body.data.results[0].tokenX;
+      expect(tokenX.symbol).toBe("MOON");
+      // enrichment (tier/decimals) still flows from tokens.xyz, untouched.
+      expect(tokenX.tier).toBe("tier3");
+      expect(tokenX.decimals).toBe(6);
     });
 
     it("defaults limit to 20 when not provided", async () => {

--- a/apps/api/src/__tests__/tokens-proxy.service.test.ts
+++ b/apps/api/src/__tests__/tokens-proxy.service.test.ts
@@ -182,13 +182,19 @@ describe("tokens-proxy service", () => {
       (global as any).fetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          mint: MINT,
           assetId: "usd",
-          symbol: "USDC",
-          name: "USD Coin",
-          decimals: 6,
-          imageUrl: null,
-          category: "stablecoin",
+          variant: {
+            mint: MINT,
+            symbol: "USDC",
+            name: "USD Coin",
+            trustTier: "tier1",
+          },
+          asset: {
+            assetId: "usd",
+            symbol: "USDC",
+            name: "USD Coin",
+            category: "stablecoin",
+          },
         }),
       });
 

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -126,7 +126,18 @@ router.get(
  *               type: object
  *               properties:
  *                 success: { type: boolean, example: true }
- *                 data: { $ref: '#/components/schemas/ResolveResult' }
+ *                 data:
+ *                   type: object
+ *                   required: [mint, assetId, symbol, name, decimals, imageUrl, category]
+ *                   properties:
+ *                     mint: { type: string, description: Solana base58 mint. }
+ *                     assetId: { type: string, nullable: true }
+ *                     symbol: { type: string, nullable: true, description: "Token symbol, or null when no source (tokens.xyz/venue/on-chain) provides one; clients render a fallback." }
+ *                     name: { type: string, nullable: true }
+ *                     decimals: { type: integer, nullable: true }
+ *                     imageUrl: { type: string, format: uri, nullable: true }
+ *                     category: { type: string, nullable: true }
+ *                     tier: { type: string, nullable: true, description: tokens.xyz trust tier. }
  *                 timestamp: { type: integer }
  *       400:
  *         description: Missing or invalid mint parameter.

--- a/apps/api/src/routes/pools.ts
+++ b/apps/api/src/routes/pools.ts
@@ -50,11 +50,16 @@ interface PoolResult {
 function toLeg(
   mint: string,
   token: PoolSearchHit["tokenA"],
-  fallbackSymbol: string | null
+  venueSymbol: string | null
 ): PoolTokenLeg {
   return {
     mint,
-    symbol: token?.symbol ?? fallbackSymbol,
+    // The venue/pool row carries the pair's real symbol (Raydium/Whirlpool
+    // ship it). Prefer it over tokens.xyz, which is null for uncurated
+    // (tier3) mints — a registry gap must never shadow a symbol the pool
+    // already gave us. tokens.xyz stays the fallback for pools whose venue
+    // recorded no symbol at all.
+    symbol: venueSymbol ?? token?.symbol ?? null,
     decimals: token?.decimals ?? null,
     logoUri: token?.logoUri ?? null,
     tier: token?.tier ?? null,

--- a/apps/api/src/services/pools-tokens.ts
+++ b/apps/api/src/services/pools-tokens.ts
@@ -79,7 +79,7 @@ export async function refreshPoolsTokens(
           // don't get the +1 star boost — without this gate, every resolved
           // mint scores stars=2 and the ranking flattens. Overrides (USDC,
           // SOL, …) carry no tier → `undefined !== "tier3"` → known=true.
-          known: asset?.tier !== "tier3",
+          known: asset != null && asset.tier !== "tier3",
           tier: asset?.tier ?? null,
           symbol: asset?.symbol ?? null,
           name: asset?.name ?? null,

--- a/apps/api/src/services/tokens-proxy.ts
+++ b/apps/api/src/services/tokens-proxy.ts
@@ -207,27 +207,29 @@ export async function resolveAsset(
   if (upstream) {
     const variant = upstream.variant ?? null;
     const asset = upstream.asset ?? null;
+    const assetId = upstream.assetId ?? asset?.assetId ?? null;
     const symbol = variant?.symbol ?? asset?.symbol ?? null;
     const name = variant?.name ?? asset?.name ?? null;
     const tier = variant?.trustTier ?? variant?.liquidityTier ?? null;
-    // Build a row whenever upstream answered — even singletons carry a useful
-    // tier. The old guard (`symbol || name`) dropped every uncurated mint,
-    // which is exactly the long tail we need to rank.
-    payload = {
-      mint,
-      assetId: upstream.assetId ?? asset?.assetId ?? null,
-      // ResolveResult.symbol is non-null by type; keep the legacy display
-      // fallback for singletons (uncurated mints with no symbol). `known`
-      // is derived downstream from the tier, not the symbol's presence.
-      symbol: symbol ?? mint.slice(0, 4) + "...",
-      name,
-      // Upstream no longer ships decimals; keep the legacy default so the
-      // column is non-null (downstream code expects a number).
-      decimals: 6,
-      imageUrl: null,
-      category: asset?.category ?? null,
-      tier,
-    };
+    // Build a row only when upstream gave us something to rank or show — a
+    // tier, symbol, name, or assetId. A singleton (uncurated mint) carries a
+    // tier3 and ranks via it; an empty body knows nothing and is a miss (→
+    // null → MINT_OVERRIDES fallback). Identity is honest: `symbol` is null
+    // when no source has one; display fallbacks live client-side.
+    if (tier || symbol || name || assetId) {
+      payload = {
+        mint,
+        assetId,
+        symbol,
+        name,
+        // Upstream no longer ships decimals; keep the legacy default so the
+        // column is non-null (downstream code expects a number).
+        decimals: 6,
+        imageUrl: null,
+        category: asset?.category ?? null,
+        tier,
+      };
+    }
   }
 
   // Fallback to baked-in MINT_OVERRIDES when upstream is unavailable.

--- a/apps/docs/beans/tributary-h7v1--pool-token-symbol-shadowed-by-synthetic-tokensxyz.md
+++ b/apps/docs/beans/tributary-h7v1--pool-token-symbol-shadowed-by-synthetic-tokensxyz.md
@@ -1,0 +1,31 @@
+---
+# tributary-h7v1
+title: Pool token symbol shadowed by synthetic tokens.xyz placeholder
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-03T00:25:05Z
+updated_at: 2026-08-03T00:25:58Z
+---
+
+GET /v1/pools/search rendered a pool's real venue symbol (e.g. MOON) as a truncated-mint placeholder (e.g. "8zTZ..."). Two causes: (1) resolveAsset fabricated mint.slice(0,4)+"..." to satisfy a non-null ResolveResult.symbol type, persisted into the tokens table; (2) toLeg preferred token.symbol over the venue symbol, so the stale/garbage token row shadowed the pool's real symbolA/symbolB. Fix: venue-first symbol precedence in toLeg; resolveAsset returns null (no slice) and builds a row only when upstream yields something rankable; known=false for null-asset mints; widen ResolveResult.symbol + TokenMetadata.symbol to string|null (app getTokenSymbolAtom already slices on null).
+
+## Summary of Changes
+
+- `routes/pools.ts` `toLeg`: venue symbol is now primary (`venueSymbol ?? token?.symbol ?? null`); a tokens.xyz registry gap can no longer shadow the symbol the pool already carries.
+- `services/tokens-proxy.ts` `resolveAsset`: returns `symbol: null` (no mint-slice) when no source has one; builds a row only when upstream yields something rankable (`tier || symbol || name || assetId`), so an empty body is a true miss → `MINT_OVERRIDES`.
+- `services/pools-tokens.ts`: `known` is `false` for genuinely-unknown (null-asset) mints, not `true`.
+- `packages/tokens-client` `types.ts` + `devnetFallback.ts`: widened `ResolveResult.symbol` and `TokenMetadata.symbol` to `string | null` (the app's `getTokenSymbolAtom` already renders a display fallback on null).
+- `routes/assets.ts`: inlined the `/v1/assets/resolve` response schema with nullable `symbol` (resolves a pre-existing dangling `$ref`).
+- Tests: corrected the `tokens-proxy` mock to the real nested `{variant, asset}` envelope; added a venue-first symbol regression test mirroring the MOON/SPCX case.
+
+## Verification
+
+- API jest: 24 suites / 303 tests pass (incl. new regression test).
+- `tokens-client` build + self-tests pass.
+- API `tsc --noEmit` and app `tsc -b`: clean.
+
+## Follow-ups (deferred)
+
+- On-chain (Metaplex) symbol as an additional identity source for symbolless mints; `packages/sdk/src/utils.ts` already exposes `getTokenSymbol()`. New bean.
+- Stale `tokens.symbol` rows holding legacy slice placeholders self-heal via the refresh loop; optional one-shot backfill `UPDATE pools.tokens SET symbol = NULL WHERE symbol ~ '^[A-Za-z0-9]{1,4}\.\.\.$';`.

--- a/packages/tokens-client/src/devnetFallback.ts
+++ b/packages/tokens-client/src/devnetFallback.ts
@@ -15,7 +15,7 @@
 export type Network = "mainnet" | "devnet" | "testnet" | "localnet";
 
 export interface TokenMetadata {
-  symbol: string;
+  symbol: string | null;
   name?: string;
   decimals?: number;
   logoURI?: string;

--- a/packages/tokens-client/src/types.ts
+++ b/packages/tokens-client/src/types.ts
@@ -49,7 +49,7 @@ export interface AssetSearchResponse {
 export interface ResolveResult {
   mint: string;
   assetId: string | null;
-  symbol: string;
+  symbol: string | null;
   name: string | null;
   decimals: number | null;
   imageUrl: string | null;


### PR DESCRIPTION
GET /v1/pools/search rendered a pool's real venue symbol (e.g. MOON) as a

truncated-mint placeholder ("8zTZ..."). Two causes:

- toLeg preferred token.symbol over the venue symbol, so a stale/garbage

  tokens row shadowed the pool's real symbolA/symbolB.

- resolveAsset fabricated mint.slice(0,4)+"..." to satisfy a non-null

  ResolveResult.symbol type, persisted into the tokens table.

Fix: venue-first symbol precedence in toLeg (a registry gap can no longer

shadow the symbol the pool already carries); resolveAsset returns null

(no slice) and builds a row only when upstream yields something rankable;

known=false for null-asset mints; widen ResolveResult.symbol and

TokenMetadata.symbol to string|null (the app's getTokenSymbolAtom already

slices on null). Inline /v1/assets/resolve schema (nullable symbol).

Tests: fix tokens-proxy mock to the real nested envelope; add a venue-first

symbol regression test mirroring the MOON/SPCX case.

Refs: tributary-h7v1